### PR TITLE
Updates benchmarks for recent OpenFOAM version

### DIFF
--- a/benchmarks/motorbike/Mesh
+++ b/benchmarks/motorbike/Mesh
@@ -1,6 +1,9 @@
 #!/bin/sh
 cd ${0%/*} || exit 1    # run from this directory
 
+# Source tutorial run functions
+. $WM_PROJECT_DIR/bin/tools/RunFunctions
+
 NX=$1
 NY=$2
 NZ=$3
@@ -11,24 +14,47 @@ echo "Setting up with $NPROCS procs.  Blockmesh size = $NX x $NY x $NZ"
 
 mkdir -p constant/polyMesh
 mkdir -p constant/triSurface
+ln -s triSurface constant/geometry
 
-sed "s/NX/$NX/g;s/NY/$NY/g;s/NZ/$NZ/g" system/blockMeshDict-mesh.in > constant/polyMesh/blockMeshDict
-cp system/decomposeParDict-mesh.in system/decomposeParDict
-
-# Source tutorial run functions
-. $WM_PROJECT_DIR/bin/tools/RunFunctions
+sed "s/NX/$NX/g;s/NY/$NY/g;s/NZ/$NZ/g" system/blockMeshDict-mesh.in > system/blockMeshDict
+cp -f system/decomposeParDict-mesh.in system/decomposeParDict
 
 # copy motorbike surface from resources directory
-cp $FOAM_TUTORIALS/resources/geometry/motorBike.obj.gz constant/triSurface/
-runApplication surfaceFeatureExtract
+cp -f $FOAM_TUTORIALS/resources/geometry/motorBike.obj.gz constant/triSurface/
+cp -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/meshQualityDict system/
+cp -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/cuttingPlane system/
+cp -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/forceCoeffs system/
+cp -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/streamLines system/
+cp -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/snappyHexMeshDict system/
+cp -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/controlDict system/
+
+# This will make total number of cells limit to 50000000(50M)
+# If you need to create mesh larger than 50M, then increase this value
+foamDictionary -entry "castellatedMeshControls.maxGlobalCells" -set "50000000" system/snappyHexMeshDict
+# This will reduce number of iteration from 500 to 250
+foamDictionary -entry "endTime" -set "250" system/controlDict
+# This will prevent writing some files and removes I/O activity
+foamDictionary -entry "writeInterval" -set "500" system/controlDict
+# This will prevent some diagnostic function calls during the run
+sed -i "s@#include@// #include@g" system/controlDict
+
+surface=$(which surfaceFeatureExtract)
+if [ ! -x $surface ]; then
+ surface=$(which surfaceFeatures)
+fi
+
+runApplication $(basename surface)
 
 runApplication blockMesh
 
 runApplication decomposePar
+
 runParallel snappyHexMesh -overwrite
+#mpirun -n $NPROCS snappyHexMesh -overwrite -parallel
 
 runApplication reconstructParMesh -constant
 rm -rf processor*
 
+# This is optional. This may improve performance and may cause more unstable result for some cases
 runApplication renumberMesh -constant -overwrite
 

--- a/benchmarks/motorbike/Mesh
+++ b/benchmarks/motorbike/Mesh
@@ -27,13 +27,18 @@ cp -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/forceCoeffs sys
 cp -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/streamLines system/
 cp -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/snappyHexMeshDict system/
 cp -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/controlDict system/
+if [ -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/surfaceFeaturesDict ]; then
+    cp -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/surfaceFeaturesDict system/
+elif [ -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/surfaceFeatureExtractDict ]; then
+    cp -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/surfaceFeatureExtractDict system/
+fi
 
-# This will make total number of cells limit to 50000000(50M)
+# This will limit global number of cell to 50000000(50M)
 # If you need to create mesh larger than 50M, then increase this value
 foamDictionary -entry "castellatedMeshControls.maxGlobalCells" -set "50000000" system/snappyHexMeshDict
 # This will reduce number of iteration from 500 to 250
 foamDictionary -entry "endTime" -set "250" system/controlDict
-# This will prevent writing some files and removes I/O activity
+# This will prevent writing some files and removes I/O activity during the run
 foamDictionary -entry "writeInterval" -set "500" system/controlDict
 # This will prevent some diagnostic function calls during the run
 sed -i "s@#include@// #include@g" system/controlDict

--- a/benchmarks/motorbike/Mesh
+++ b/benchmarks/motorbike/Mesh
@@ -14,7 +14,9 @@ echo "Setting up with $NPROCS procs.  Blockmesh size = $NX x $NY x $NZ"
 
 mkdir -p constant/polyMesh
 mkdir -p constant/triSurface
-ln -s triSurface constant/geometry
+if [ ! -f constant/geometry ]; then
+    ln -s triSurface constant/geometry
+fi
 
 sed "s/NX/$NX/g;s/NY/$NY/g;s/NZ/$NZ/g" system/blockMeshDict-mesh.in > system/blockMeshDict
 cp -f system/decomposeParDict-mesh.in system/decomposeParDict
@@ -29,8 +31,10 @@ cp -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/snappyHexMeshDi
 cp -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/controlDict system/
 if [ -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/surfaceFeaturesDict ]; then
     cp -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/surfaceFeaturesDict system/
+    surface=$(which surfaceFeatures)
 elif [ -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/surfaceFeatureExtractDict ]; then
     cp -f $FOAM_TUTORIALS/incompressible/simpleFoam/motorBike/system/surfaceFeatureExtractDict system/
+    surface=$(which surfaceFeatureExtract)
 fi
 
 # This will limit global number of cell to 50000000(50M)
@@ -43,12 +47,7 @@ foamDictionary -entry "writeInterval" -set "500" system/controlDict
 # This will prevent some diagnostic function calls during the run
 sed -i "s@#include@// #include@g" system/controlDict
 
-surface=$(which surfaceFeatureExtract)
-if [ ! -x $surface ]; then
- surface=$(which surfaceFeatures)
-fi
-
-runApplication $(basename surface)
+runApplication $(basename $surface)
 
 runApplication blockMesh
 

--- a/benchmarks/motorbike/README.org
+++ b/benchmarks/motorbike/README.org
@@ -18,6 +18,9 @@ Here is an example of the sizes of mesh that are created for different values:
 |    80 |    32 |    32 |    11.2  |
 |    90 |    36 |    36 |    15.5  |
 |   100 |    40 |    40 |    20    |
+|   130 |    52 |    52 |    42    |
+|   150 |    60 |    60 |    64    |
+|   200 |    80 |    80 |   145    |
 |-------+-------+-------+----------|
 
 It is recommended to keep the same proportions here.

--- a/benchmarks/motorbike/Setup
+++ b/benchmarks/motorbike/Setup
@@ -1,19 +1,17 @@
 #!/bin/sh
 cd ${0%/*} || exit 1    # run from this directory
 
+# Source tutorial run functions
+. $WM_PROJECT_DIR/bin/tools/RunFunctions
+
 NPROCS=$1
 
 echo "Running with $NPROCS procs."
 
-rm -f log.*
-rm -rf processor*
-
 sed "s/NPROCS/$NPROCS/g" system/decomposeParDict-solve.in > system/decomposeParDict
 
-# Source tutorial run functions
-. $WM_PROJECT_DIR/bin/tools/RunFunctions
-
-runApplication decomposePar
+rm -rf processor*
+runApplication -a decomposePar
 
 #- For non-parallel running
 #cp -r 0.org 0 > /dev/null 2>&1
@@ -22,6 +20,10 @@ runApplication decomposePar
 ls -d processor* | xargs -I {} rm -rf ./{}/0
 ls -d processor* | xargs -I {} cp -r 0.org ./{}/0
 
+runParallel checkMesh
+#mpirun -n $NPROCS checkMesh -parallel
+
 runParallel potentialFoam
+#mpirun -n $NPROCS potentialFoam -parallel
 
 # ----------------------------------------------------------------- end-of-file

--- a/benchmarks/motorbike/Solve
+++ b/benchmarks/motorbike/Solve
@@ -9,5 +9,6 @@ cd ${0%/*} || exit 1    # run from this directory
 #           mpirun -np $NPROCS simpleFoam -parallel
 #
 runParallel simpleFoam
+#mpirun -n $(getNumberOfProcessors) simpleFoam -parallel
 
 # ----------------------------------------------------------------- end-of-file

--- a/benchmarks/motorbike/system/surfaceFeaturesDict
+++ b/benchmarks/motorbike/system/surfaceFeaturesDict
@@ -1,0 +1,31 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Version:  6
+     \\/     M anipulation  |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      surfaceFeaturesDict;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+surfaces ("motorBike.obj");
+
+// Identify a feature when angle between faces < includedAngle
+includedAngle       150;
+
+subsetFeatures
+{
+    // Keep nonManifold edges (edges with >2 connected faces)
+    nonManifoldEdges       no;
+
+    // Keep open edges (edges with 1 connected face)
+    openEdges       yes;
+}
+
+// ************************************************************************* //


### PR DESCRIPTION
The current customized motorbike benchmark does not work well with recent OpenFOAM version 7 and 8.
So copying some dictionary files from OpenFOAM source repository is necessary and surfaceFeatures should replace surfaceFeatureExtract in recent version.
The modified one will work well from old version(5.0) to recent development version(OpenFOAM-dev branch).